### PR TITLE
Fix - TS LSP config deprecated

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -162,7 +162,7 @@ return {
       --    https://github.com/pmizio/typescript-tools.nvim
       --
       -- But for many setups, the LSP (`tsserver`) will work just fine
-      tsserver = {},
+      ts_ls = {},
       ruff = {},
       pylsp = {
         settings = {

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -162,7 +162,7 @@ return {
       --    https://github.com/pmizio/typescript-tools.nvim
       --
       -- But for many setups, the LSP (`tsserver`) will work just fine
-      ts_ls = {},
+      ts_ls = {}, -- tsserver is deprecated
       ruff = {},
       pylsp = {
         settings = {


### PR DESCRIPTION
hey there, tsserver is deprecated and recently got replaced by ts_ls, therefore i fixed the lsp config. 

keep up the good work, really enjoyed the session! 