### PR TITLE
fix: load nvim-cmp before mp-nvim-lsp

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -1,6 +1,7 @@
 return {
   -- Main LSP Configuration
   'neovim/nvim-lspconfig',
+  'hrsh7th/nvim-cmp',
   dependencies = {
     -- Automatically install LSPs and related tools to stdpath for Neovim
     { 'williamboman/mason.nvim', config = true }, -- NOTE: Must be loaded before dependants


### PR DESCRIPTION
nvim-cmp must be loaded before cmp-nvim-lsp.

or you will get error like below:

```
Error detected while processing InsertEnter Autocommands for "*":
Error executing lua callback: ...l/share/nvim/lazy/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:98: module 'cmp' not found:
        no field package.preload['cmp']
cache_loader: module cmp not found
cache_loader_lib: module cmp not found
        no file './cmp.lua'
        no file '/opt/homebrew/share/luajit-2.1/cmp.lua'
        no file '/usr/local/share/lua/5.1/cmp.lua'
        no file '/usr/local/share/lua/5.1/cmp/init.lua'
        no file '/opt/homebrew/share/lua/5.1/cmp.lua'
        no file '/opt/homebrew/share/lua/5.1/cmp/init.lua'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/image.nvim/share/lua/5.1/cmp.lua'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/image.nvim/share/lua/5.1/cmp/init.lua'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/cmp.lua'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/cmp/init.lua'
        no file './cmp.so'
        no file '/usr/local/lib/lua/5.1/cmp.so'
        no file '/opt/homebrew/lib/lua/5.1/cmp.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/image.nvim/lib/lua/5.1/cmp.so'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/image.nvim/lib64/lua/5.1/cmp.so'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/telescope.nvim/lib/lua/5.1/cmp.so'
        no file '/Users/liaoxingyi/.local/share/nvim/lazy-rocks/telescope.nvim/lib64/lua/5.1/cmp.so'
stack traceback:
        [C]: in function 'require'
        ...l/share/nvim/lazy/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:98: in function <...l/share/nvim/lazy/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:9
7>
Press ENTER or type command to continue
```

