### PR TITLE
Fix file ignore patterns in telescope configuration

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -58,11 +58,11 @@ return {
       },
       pickers = {
         find_files = {
-          file_ignore_patterns = { 'node_modules', '.git', '.venv' },
+          file_ignore_patterns = { 'node_modules', '%.git', '%.venv' },
           hidden = true,
         },
         live_grep = {
-          file_ignore_patterns = { 'node_modules', '.git', '.venv' },
+          file_ignore_patterns = { 'node_modules', '%.git', '%.venv' },
           additional_args = function(_)
             return { '--hidden' }
           end,


### PR DESCRIPTION
Fix: Telescope was ignoring files with "git" or "venv" in their name due to unescaped dot in file_ignore_patterns.